### PR TITLE
Keep anchorPoint the same when retexturing

### DIFF
--- a/DSMultilineLabelNode.m
+++ b/DSMultilineLabelNode.m
@@ -116,10 +116,6 @@
     
     SKSpriteNode *selfNode = (SKSpriteNode*) self;
     selfNode.texture = newTexture;
-    
-    //Resetting the texture also reset the anchorPoint.  Let's recenter it.
-    selfNode.anchorPoint = CGPointMake(0.5, 0.5);
-
 }
 
 -(DSMultiLineLabelImage *)imageFromText:(NSString *)text


### PR DESCRIPTION
This allows the owner to set a custom `anchorPoint` and not have the value reset to `(0.5,0.5)` on other property changes.

The comment indicates that the resetting the texture also resets the `anchorPoint`, but I could not reproduce. If it's reproducible, though, I could record the `anchorPoint` value in a local variable before the retexture and then restore it afterwards.
